### PR TITLE
lib-input-regexp: Stricter checking and helper tooltip

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.css
@@ -5,3 +5,51 @@ input {
 .invalid {
     color: red;
 }
+.regexp-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-left: 5px;
+    margin-right: -5px;
+}
+/* Adapted from https://www.w3schools.com/css/css_tooltip.asp */
+.regexp-tooltip {
+    position: absolute;
+    top: 150%;
+    z-index: 5;
+    background-color: #FEE;
+    color: var(--theme-error-color);
+    text-align: center;
+    font-size: 0.9em;
+    padding: 5px 10px;
+    border-radius: 6px;
+    animation: 10s appearDisappear;
+    visibility: hidden;
+}
+.regexp-tooltip::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    border-width: 10px;
+    border-style: solid;
+    border-color: transparent transparent #FEE transparent;
+    left: 47.5%;
+}
+@keyframes appearDisappear {
+    0% {
+        opacity: 0;
+    }
+    20% {
+        opacity: 0;
+        visibility: visible;
+    }
+    25% {
+        opacity: 1;
+    }
+    95% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.css
@@ -53,3 +53,12 @@ input {
         opacity: 0;
     }
 }
+/* Adapted from https://github.com/just-the-docs/just-the-docs/blob/b5345f2/_sass/code.scss */
+.regexp-tooltip code {
+    padding: 0.2em 0.15em;
+    font-weight: 400;
+    background-color: #f5f6fa;
+    border: 1px solid #eeebee;
+    border-radius: 3px;
+    color: black;
+}

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
@@ -1,15 +1,15 @@
 <div class="regexp-container">
-<input
-  type="text"
-  class="regexp {{className}} {{regexpValid?'':'invalid'}}"
-  name="{{name}}"
-  id="{{id}}"
-  title="{{temporaryTitle || title}}"
-  placeholder="{{placeholder}}"
-  (input)="checkRegularExpression($event)"
-  [(ngModel)]="value"
-  (ngModelChange)="valueChange.emit(value)"
-  [appAutofocus]="autofocus?true:false">
+  <input
+    type="text"
+    class="regexp {{className}} {{regexpValid?'':'invalid'}}"
+    name="{{name}}"
+    id="{{id}}"
+    title="{{temporaryTitle || title}}"
+    placeholder="{{placeholder}}"
+    (input)="checkRegularExpression($event)"
+    [(ngModel)]="value"
+    (ngModelChange)="valueChange.emit(value)"
+    [appAutofocus]="autofocus?true:false">
   <span
     *ngIf="!regexpValid"
     class="regexp-tooltip"

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
@@ -1,7 +1,8 @@
 <div class="regexp-container">
   <input
     type="text"
-    class="regexp {{className}} {{regexpValid?'':'invalid'}}"
+    class="regexp {{className}}"
+    [class.invalid]="regexpError"
     name="{{name}}"
     id="{{id}}"
     title="{{temporaryTitle || title}}"
@@ -11,7 +12,7 @@
     (ngModelChange)="valueChange.emit(value)"
     [appAutofocus]="autofocus?true:false">
   <span
-    *ngIf="!regexpValid"
+    *ngIf="regexpError"
     class="regexp-tooltip"
-    >{{ temporaryTitle }}</span>
+    >Invalid regular expression <code>{{value}}</code>: {{ regexpError }}</span>
 </div>

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.html
@@ -1,3 +1,4 @@
+<div class="regexp-container">
 <input
   type="text"
   class="regexp {{className}} {{regexpValid?'':'invalid'}}"
@@ -9,3 +10,8 @@
   [(ngModel)]="value"
   (ngModelChange)="valueChange.emit(value)"
   [appAutofocus]="autofocus?true:false">
+  <span
+    *ngIf="!regexpValid"
+    class="regexp-tooltip"
+    >{{ temporaryTitle }}</span>
+</div>

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -25,7 +25,7 @@ export class InputRegexpComponent implements OnInit {
     checkRegularExpression(event: any): void {
         const value = event.target.value;
         try {
-            new RegExp(value);
+            new RegExp(value, "u");
             this.regexpValid = true;
             // if it's a long regular expression...
             this.temporaryTitle = value.length>10
@@ -35,7 +35,7 @@ export class InputRegexpComponent implements OnInit {
                 :null;
         } catch(error) {
             this.regexpValid = false;
-            this.temporaryTitle = error.message;
+            this.temporaryTitle = error.message.replace(': ', ' ').replace('/u:', '/:');
         }
     }
 }

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -15,7 +15,7 @@ export class InputRegexpComponent implements OnInit {
     @Output() valueChange = new EventEmitter<string>();
     @Input() autofocus: boolean;
     temporaryTitle: string;
-    regexpValid = true;
+    regexpError: string;
     
     constructor() { }
     
@@ -26,7 +26,7 @@ export class InputRegexpComponent implements OnInit {
         const value = event.target.value;
         try {
             new RegExp(value, "u");
-            this.regexpValid = true;
+            this.regexpError = "";
             // if it's a long regular expression...
             this.temporaryTitle = value.length>10
             // show the regular expression as the tool-tip
@@ -34,8 +34,8 @@ export class InputRegexpComponent implements OnInit {
             // but otherwise, use the given title
                 :null;
         } catch(error) {
-            this.regexpValid = false;
             this.temporaryTitle = error.message.replace(': ', ' ').replace('/u:', '/:');
+            this.regexpError = error.message.match("(?<=/u: ).+");
         }
     }
 }

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -35,7 +35,7 @@ export class InputRegexpComponent implements OnInit {
                 :null;
         } catch(error) {
             this.regexpValid = false;
-            this.temporaryTitle = error;
+            this.temporaryTitle = error.message;
         }
     }
 }


### PR DESCRIPTION
Stricter checking: Things like unmatched unescaped `{` weren't caught by `new Regexp()` but would yield "java.sql.SQLException: Syntax error in regular expression" errors when running the search
