### PR TITLE
lib-layer-filter: bugfix

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-filter/layer-filter.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-filter/layer-filter.component.ts
@@ -58,6 +58,10 @@ export class LayerFilterComponent implements OnInit {
     }
     
     handleRangeChange(i: number, value: string): void {
+        // ensure both bounds exist
+        if (!this.values.length) {
+            this.values = ['',''];
+        }
         this.values[i] = value;
         this.changeValues.emit(this.values);
     }


### PR DESCRIPTION
On _participants_ or _transcripts_, after filters are cleared, prevent range lower bound from being parsed as regex to match