### PR TITLE
input-regexp: Don't flag `\-` outside `[]`

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -26,16 +26,24 @@ export class InputRegexpComponent implements OnInit {
         const value = event.target.value;
         try {
             new RegExp(value, "u");
-            this.regexpError = "";
-            // if it's a long regular expression...
-            this.temporaryTitle = value.length>10
-            // show the regular expression as the tool-tip
-                ?value
-            // but otherwise, use the given title
-                :null;
+            this.validRegexp(value);
         } catch(error) {
-            this.temporaryTitle = error.message.replace(': ', ' ').replace('/u:', '/:');
-            this.regexpError = error.message.match("(?<=/u: ).+");
+            if (error.message.endsWith("Invalid escape")) {
+                this.validRegexp(value);
+            } else {
+                this.temporaryTitle = error.message.replace(': ', ' ').replace('/u:', '/:');
+                this.regexpError = error.message.match("(?<=/u: ).+");
+            }
         }
+    }
+    
+    validRegexp(regexp: string): void {
+        this.regexpError = "";
+        // if it's a long regular expression...
+        this.temporaryTitle = regexp.length>10
+        // show the regular expression as the tool-tip
+            ?regexp
+        // but otherwise, use the given title
+            :null;
     }
 }


### PR DESCRIPTION
JS's new Regexp(re, 'u') throws an "Invalid escape" error when hyphens are escaped outside a character class, but this over-escaping doesn't create any issues for MySQL search.
In my view, over-escaping isn't a problem because it can [lessen the regex learning curve](https://github.com/nzilbb/labbcat-server/pull/66/commits/011085dc485eca2466145e3f499f7441aec6b022), and we're not playing regex golf here!