### PR TITLE
transcript: Use replaceAll for interpreted labels r/t replace

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.ts
@@ -902,7 +902,7 @@ export class TranscriptComponent implements OnInit {
                     && (display == definition.label // replace whole labels only
                         || annotation.layer.type == "ipa") // unless it's a phonological layer
                    ) { // there is a display version of this label
-                    display = display.replace(definition.label, definition.display);
+                    display = display.replaceAll(definition.label, definition.display);
                     if (annotation.layer.type != "ipa") { // whole label replaced
                         break;
                     }


### PR DESCRIPTION
Current (_phonemes_ - _word_ - _segment_): 
![image](https://github.com/user-attachments/assets/c9231141-a1f0-4af9-b321-665a042c95a2)

Proposed: 
![image](https://github.com/user-attachments/assets/21752100-d956-44b7-9157-4bcc65fdc56c)

(Specifically, https://apls.pitt.edu/labbcat/transcript?transcript=CB01interview3.eaf#ew_0_692153)