### PR TITLE
layer-checkboxes: Add empty space for no vertical peers

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.css
@@ -66,6 +66,9 @@ img.data-type, img.alignment, img.vertical-peers {
     margin-right: 0.2rem;
     cursor: help;
 }
+img.vertical-peers.spacer {
+    margin-right: 1.2rem;
+}
 .layer-count:before {
     content: ' (';
 }

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.html
@@ -136,7 +136,9 @@
            i18n-title="Layer alignment descriptions"
            [title]="'Alignment: ' + (['turn','word','segment'].includes(layer.id) && spoofAlignment ? 'Complete interval' : layer.alignment==2? 'Sub-interval' :layer.alignment==1? 'Timepoint' : 'Complete interval')"
            [alt]="['turn','word','segment'].includes(layer.id) && spoofAlignment ? '[🏷]' : layer.alignment==2? '[↔]' :layer.alignment==1? '[📌]' : '[🏷]' ">
-      <img *ngIf="includeVerticalPeers" class="vertical-peers"
+      <img *ngIf="includeVerticalPeers"
+           class="vertical-peers"
+           [class.spacer]="!layer.peersOverlap"
            [style.display]="displayIcons ? 'inline' : 'none'"
            [src]="layer.peersOverlap ? imagesLocation + '/vertical-peers'+(this.disabled.includes(layer.id) ? '-disabled' : '')+'.svg' : undefined" 
            [alt]="layer.peersOverlap ? '[|=]' : ''"
@@ -219,7 +221,9 @@
            i18n-title="Layer alignment descriptions"
            [title]="'Alignment: ' + (['turn','word','segment'].includes(layer.id) && spoofAlignment ? 'Complete interval' : layer.alignment==2? 'Sub-interval' :layer.alignment==1? 'Timepoint' : 'Complete interval')"
            [alt]="['turn','word','segment'].includes(layer.id) && spoofAlignment ? '[🏷]' : layer.alignment==2? '[↔]' :layer.alignment==1? '[📌]' : '[🏷]' ">
-      <img *ngIf="includeVerticalPeers" class="vertical-peers"
+      <img *ngIf="includeVerticalPeers"
+           class="vertical-peers"
+           [class.spacer]="!layer.peersOverlap"
            [style.display]="displayIcons ? 'inline' : 'none'"
            [src]="layer.peersOverlap ? imagesLocation + '/vertical-peers'+(this.disabled.includes(layer.id) ? '-disabled' : '')+'.svg' : undefined" 
            [alt]="layer.peersOverlap ? '[|=]' : ''"
@@ -306,7 +310,9 @@
            i18n-title="Layer alignment descriptions"
            [title]="'Alignment: ' + (['turn','word','segment'].includes(layer.id) && spoofAlignment ? 'Complete interval' : layer.alignment==2? 'Sub-interval' :layer.alignment==1? 'Timepoint' : 'Complete interval')"
            [alt]="['turn','word','segment'].includes(layer.id) && spoofAlignment ? '[🏷]' : layer.alignment==2? '[↔]' :layer.alignment==1? '[📌]' : '[🏷]' ">
-      <img *ngIf="includeVerticalPeers" class="vertical-peers"
+      <img *ngIf="includeVerticalPeers"
+           class="vertical-peers"
+           [class.spacer]="!layer.peersOverlap"
            [style.display]="displayIcons ? 'inline' : 'none'"
            [src]="layer.peersOverlap ? imagesLocation + '/vertical-peers'+(this.disabled.includes(layer.id) ? '-disabled' : '')+'.svg' : undefined" 
            [alt]="layer.peersOverlap ? '[|=]' : ''"
@@ -390,7 +396,9 @@
            i18n-title="Layer alignment descriptions"
            [title]="'Alignment: ' + (['turn','word','segment'].includes(layer.id) && spoofAlignment ? 'Complete interval' : layer.alignment==2? 'Sub-interval' :layer.alignment==1? 'Timepoint' : 'Complete interval')"
            [alt]="['turn','word','segment'].includes(layer.id) && spoofAlignment ? '[🏷]' : layer.alignment==2? '[↔]' :layer.alignment==1? '[📌]' : '[🏷]' ">
-      <img *ngIf="includeVerticalPeers" class="vertical-peers"
+      <img *ngIf="includeVerticalPeers"
+           class="vertical-peers"
+           [class.spacer]="!layer.peersOverlap"
            [style.display]="displayIcons ? 'inline' : 'none'"
            [src]="layer.peersOverlap ? imagesLocation + '/vertical-peers'+(this.disabled.includes(layer.id) ? '-disabled' : '')+'.svg' : undefined" 
            [alt]="layer.peersOverlap ? '[|=]' : ''"


### PR DESCRIPTION
Per #68, this makes the layer IDs line up nicely:

![image](https://github.com/user-attachments/assets/c4dac57f-4497-4a45-af94-b7bd06bd2af2)

The downside is that if projects are in use, the default view has no layers w/ vertical peers so it looks a little weird:

![image](https://github.com/user-attachments/assets/f48ef0f4-861c-4831-ac5e-f832a54e843f)

As a result, I'm not sure if I'll implement this one in APLS