### PR TITLE
Style: Add missing combinator for attribute lists

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-view/src/styles.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/styles.css
@@ -503,7 +503,7 @@ tbody tr:nth-child(even) {
         padding: 4px;
         &:nth-child(odd)  { background: #EEEEEE; }
         &:nth-child(even) { background: #FFFFFF; }
-        & label {
+        & > label {
             width: 50%;
             &:after { content: ':'; }
         }


### PR DESCRIPTION
This fixes a bug where trailing colons showed up in the lib-link and lib-button labels in the tabs on the transcript page