### PR TITLE
search: Fix options alignment (cf. 352b1dd)

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/search/search.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/search/search.component.css
@@ -108,6 +108,7 @@ details[open] > div {
     content: ':';
 }
 .list {
+    margin: unset;
     margin-top: 5px;
 }
 .list-label {

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/search/search.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/search/search.component.css
@@ -108,7 +108,7 @@ details[open] > div {
     content: ':';
 }
 .list {
-    margin: unset;
+    width: 100%;
     margin-top: 5px;
 }
 .list-label {


### PR DESCRIPTION
Before:
<img width="1165" height="369" alt="image" src="https://github.com/user-attachments/assets/f1054db4-f5b9-4a0c-a1ec-521a43848b18" />

After:
<img width="1172" height="362" alt="image" src="https://github.com/user-attachments/assets/dafa2309-70c3-4f45-930b-41dd59b41485" />
