### PR TITLE
matches-upload: Add missing padding

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches-upload/matches-upload.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches-upload/matches-upload.component.css
@@ -10,6 +10,9 @@
 #file-chooser details {
     padding-top: 5px;
 }
+#rowCount {
+    padding-left: 1ch;
+}
 .header {
     padding-top: 10px;
     font-weight: 700;


### PR DESCRIPTION
Before:
<img width="769" height="43" alt="image" src="https://github.com/user-attachments/assets/9667482a-bcaa-44fc-b97a-c32cbd47cab9" />

After:
<img width="778" height="43" alt="image" src="https://github.com/user-attachments/assets/dfbedf0e-53dc-45c9-a80e-776b4b96dd16" />

(All the other `#rowCount`s are already padded.)