### PR TITLE
transcript: Add 'Copy transcript text' to word menu

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.html
@@ -790,6 +790,14 @@
                     i18n-title title="Extract audio fragment for this utterance"
                     ></lib-menu-option>
                 </div>
+                <div class="item" id="copy-utterance-text-option">
+                  <lib-menu-option
+                    (press)="copyTranscriptText(utterance); menuId = null"
+                    img="fa-copy.svg" icon="📋"
+                    i18n-label label="Copy transcript text"
+                    i18n-title title="Copy word annotations for this utterance"
+                    ></lib-menu-option>
+                </div>
                 <ng-container *ngIf="hasWAV && praatIntegration">
                   <div class="item" id="praat-open">
                     <lib-menu-option        

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/transcript/transcript.component.ts
@@ -1897,6 +1897,12 @@ export class TranscriptComponent implements OnInit {
             });
         } // 'edit' user
     }
+    /** Copy text of utterance */
+    copyTranscriptText(annotation: Annotation): void {
+        const transcriptText = annotation.all(this.schema.wordLayerId).map(a => a.label).join(' ');
+        navigator.clipboard.writeText(transcriptText);
+        alert("Copied transcript text to clipboard:\n\n" + transcriptText);
+    }
     /** Participants button actions */
     viewAttributes(participant: string): void {
         this.router.navigate(["participant"], {

--- a/user-interface/src/main/angular/projects/labbcat-view/src/assets/fa-copy.svg
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/assets/fa-copy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+  <!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+  <!-- https://fontawesome.com/icons/classic/solid/copy -->
+  <path d="M288 64C252.7 64 224 92.7 224 128L224 384C224 419.3 252.7 448 288 448L480 448C515.3 448 544 419.3 544 384L544 183.4C544 166 536.9 149.3 524.3 137.2L466.6 81.8C454.7 70.4 438.8 64 422.3 64L288 64zM160 192C124.7 192 96 220.7 96 256L96 512C96 547.3 124.7 576 160 576L352 576C387.3 576 416 547.3 416 512L416 496L352 496L352 512L160 512L160 256L176 256L176 192L160 192z"
+        style="fill:#859044"/>
+</svg>


### PR DESCRIPTION
New option:
<img width="1474" height="383" alt="image" src="https://github.com/user-attachments/assets/fb1deb92-b391-4c21-b898-f31766b4776e" />

When clicked:
<img width="550" height="307" alt="image" src="https://github.com/user-attachments/assets/591e51b9-22f4-46c8-93d5-574b861e4d87" />
