### PR TITLE
input-regexp: More closely mirror java.sql regex checking (#162)

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -26,6 +26,15 @@ export class InputRegexpComponent implements OnInit {
         const value = event.target.value;
         // prevent errors thrown by [[a][b]], since this pattern isn't problematic for MySQL
         const checkValue = value.replace(/\[([^[]*)\[([^[\]]+)\]([^[\]]*)\[([^[\]]+)\]([^[\]]*)\]/,'[$1$2$3$4$5]');
+        // catch patterns that will error for java.sql but don't in new Regexp(): unmatched [, empty []
+        if ((checkValue.match(/\[/g) || []).length > (checkValue.match(/\]/g) || []).length) {
+            this.regexpError = 'Unterminated character class';
+            this.temporaryTitle = 'Invalid regular expression /' + value + '/: ' + this.regexpError;
+        } else if (checkValue.match(/\[\]/)) {
+            this.regexpError = 'Empty character class';
+            this.temporaryTitle = 'Invalid regular expression /' + value + '/: ' + this.regexpError;
+        } else {
+        // check regexp
         try {
             new RegExp(checkValue, "u");
             this.validRegexp(value);
@@ -37,6 +46,7 @@ export class InputRegexpComponent implements OnInit {
                 this.regexpError = error.message.replace(/Invalid regular expression: (\/.+\/u: )?/, '');
                 this.temporaryTitle = 'Invalid regular expression /' + value + '/: ' + this.regexpError;
             }
+        }
         }
     }
     

--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/input-regexp/input-regexp.component.ts
@@ -24,13 +24,15 @@ export class InputRegexpComponent implements OnInit {
 
     checkRegularExpression(event: any): void {
         const value = event.target.value;
+        // prevent errors thrown by [[a][b]], since this pattern isn't problematic for MySQL
+        const checkValue = value.replace(/\[([^[]*)\[([^[\]]+)\]([^[\]]*)\[([^[\]]+)\]([^[\]]*)\]/,'[$1$2$3$4$5]');
         try {
-            new RegExp(value, "u");
+            new RegExp(checkValue, "u");
             this.validRegexp(value);
         } catch(error) {
             if (error.message.endsWith("Invalid escape") || error.message.endsWith("invalid identity escape in regular expression") || error.message.endsWith("invalid escaped character for Unicode pattern")) {
                 // ignore errors thrown by \- outside [], since this pattern isn't problematic for MySQL
-                this.validRegexp(value);
+                this.validRegexp(checkValue);
             } else {
                 this.regexpError = error.message.replace(/Invalid regular expression: (\/.+\/u: )?/, '');
                 this.temporaryTitle = 'Invalid regular expression /' + value + '/: ' + this.regexpError;


### PR DESCRIPTION
Eliminates:
* False positive (error thrown by JS's `new RegExp(re, 'u')` but not java.sql): Nested character classes like `[[7][8]]`
* False negative (user doesn't see the error until hitting _Search_): Unterminated character classes like `[[7][8]` (`new RegExp()` throws an error only if there's a single unmatched `[`)
* False negative: Empty character classes like `[]`