### PR TITLE
matches: Better match between what shows up in CSV and what shows up in CSV Export panel

### DIFF
--- a/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-common/src/lib/layer-checkboxes/layer-checkboxes.component.ts
@@ -16,6 +16,8 @@ export class LayerCheckboxesComponent implements OnInit {
     @Input() schema: any;
     /** name attribute for checkboxes */
     @Input() name: string;
+    /** Display "participant"/"transcript" as they're exported to CSV ("Speaker"/"Transcript") */
+    @Input() displayCsvNames: boolean;
     /** Allow an annotation count to be specified when a layer is selected */
     @Input() includeCounts: boolean;
     /** Allow start/end anchoring to be specified when a layer is selected */
@@ -228,12 +230,18 @@ export class LayerCheckboxesComponent implements OnInit {
     }
 
     ParticipantLayerLabel(id): string {
+        if (id == this.schema.participantLayerId && this.displayCsvNames) {
+            return "Speaker"; // TODO i18n
+        }
         if (id == this.schema.participantLayerId && this.scopeCount > 1) {
             return "Name"; // TODO i18n
         }
         else return id.replace(/^participant_/,"");
     }
     TranscriptLayerLabel(id): string {
+        if (id == this.schema.root.id && this.displayCsvNames) {
+            return "Transcript"; // TODO i18n
+        }
         if (id == this.schema.root.id && this.scopeCount > 1) {
             return "Name"; // TODO i18n
         }

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.css
@@ -49,12 +49,22 @@
     display: flex;
     flex-direction: column;
 }
-.csv-options {
+.csv-options-wrapper {
     display: flex;
     flex-direction: column;
 }
+.csv-options {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 2px;
+    flex-grow: 1;
+}
 .csv-options label {
     white-space: nowrap;
+}
+.csv-controls {
+    padding: 0;
+    font-style: italic;
 }
 lib-layer-checkboxes {
     display: flex;
@@ -71,10 +81,6 @@ input[type="checkbox"]:disabled {
 }
 label > span {
     display: inline-block;
-}
-.header {
-    padding-top: 10px;
-    font-weight: 700;
 }
 @media all and (min-width: 640px) {
     .csv-checkboxes {

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.css
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.css
@@ -58,9 +58,14 @@
     flex-direction: column;
     margin-bottom: 2px;
     flex-grow: 1;
+    padding: 0;
+    span {
+        padding-left: 4px;
+    }
 }
 .csv-options label {
     white-space: nowrap;
+    padding: 1px;
 }
 .csv-controls {
     padding: 0;

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
@@ -152,6 +152,7 @@
     <fieldset>
       <legend i18n>CSV columns</legend>
       <div class="csv-checkboxes">
+        <div class="csv-options-wrapper">
         <fieldset class="csv-options">
           <legend i18n="csv options title" class="header">Fields</legend>
           <label i18n-title title="Title of this LaBB-CAT database - always exported">
@@ -161,13 +162,15 @@
                    [disabled]="precheckedCsvOptions.includes('labbcat_title')">
             <input type="hidden" name="csv_option" value="labbcat_title"
                    *ngIf="precheckedCsvOptions.includes('labbcat_title')">
-            <span i18n="csv options">Database title</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Database title</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Title</span>
           </label>
           <label i18n-title title="This database's LaBB-CAT version">
             <input type="checkbox" name="csv_option"
                    value="labbcat_version"
                    [checked]="precheckedCsvOptions.includes('labbcat_version')">
-            <span i18n="csv options">LaBB-CAT version</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">LaBB-CAT version</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Version</span>
           </label>
           <label i18n-title title="Version of the corpus data - always exported">
             <input type="checkbox" name="csv_option"
@@ -176,7 +179,8 @@
                    [disabled]="precheckedCsvOptions.includes('data_version')">
             <input type="hidden" name="csv_option" value="data_version"
                    *ngIf="precheckedCsvOptions.includes('data_version')">
-            <span i18n="csv options">Data version</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Data version</span>
+            <span *ngIf="displayExportNames" i18n="csv options">DataVersion</span>
           </label>
           <label i18n-title title="Identifier for this search - always exported">
             <input type="checkbox" name="csv_option"
@@ -186,36 +190,42 @@
             <input type="hidden" name="csv_option"
                    value="collection_name"
                    *ngIf="precheckedCsvOptions.includes('collection_name')">
-            <span i18n="csv options">Search name</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Search name</span>
+            <span *ngIf="displayExportNames" i18n="csv options">SearchName</span>
           </label>
           <label i18n-title title="Result number">
             <input type="checkbox" name="csv_option"
                    value="result_number"
                    [checked]="precheckedCsvOptions.includes('result_number')">
-            <span i18n="csv options">Result number</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Result number</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Number</span>
           </label>
           <label i18n-title title="Start time of the transcript relative to the beginning of the whole episode">
             <input type="checkbox" name="csv_option"
                    value="series_offset"
                    [checked]="precheckedCsvOptions.includes('series_offset')">
-            <span i18n="csv options">Episode offset</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Episode offset</span>
+            <span *ngIf="displayExportNames" i18n="csv options">SeriesOffset</span>
           </label>
           <label i18n-title title="End time of the transcript relative to the beginning of the whole episode">
             <input type="checkbox" name="csv_option"
                    value="series_length"
                    [checked]="precheckedCsvOptions.includes('series_length')">
-            <span i18n="csv options">Episode length</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Episode length</span>
+            <span *ngIf="displayExportNames" i18n="csv options">SeriesLength</span>
           </label>
           <label i18n-title title="Start time of the utterance relative to the beginning of the transcript">
             <input type="checkbox" name="csv_option"
                    value="line_time"
                    [checked]="precheckedCsvOptions.includes('line_time')">
-            <span i18n="csv options">Line start</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Line start</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Line</span>
           </label>
           <label i18n-title title="End time of the utterance relative to the beginning of the transcript">
             <input type="checkbox" name="csv_option" value="line_end_time"
                    [checked]="precheckedCsvOptions.includes('line_end_time')">
-            <span i18n="csv options">Line end</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Line end</span>
+            <span *ngIf="displayExportNames" i18n="csv options">LineEnd</span>
           </label>
           <label i18n-title title="Unique identifier for the match - always exported">
             <input type="checkbox" name="csv_option"
@@ -224,7 +234,8 @@
                    [disabled]="precheckedCsvOptions.includes('match')">
             <input type="hidden" name="csv_option" value="match"
                    *ngIf="precheckedCsvOptions.includes('match')">
-            <span i18n="csv options">Match ID</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Match ID</span>
+            <span *ngIf="displayExportNames" i18n="csv options">MatchId</span>
           </label>
           <label i18n-title title="URL for the match - always exported">
             <input type="checkbox" name="csv_option"
@@ -258,6 +269,14 @@
             <span i18n="csv options">After Match</span>
           </label>
         </fieldset>
+          <fieldset class="csv-controls">
+            <label i18n-title title="Display field names as they appear in the exported CSV">
+              <input type="checkbox" name="displayExportNames"
+                [checked]="displayExportNames" (change)="toggleExportNames()">
+              <span i18n>Show export names</span>
+            </label>
+          </fieldset>
+        </div>
         <!-- TODO disable segment layer anchoring when segment is targeted -->
         <lib-layer-checkboxes
           name="csv_layer"

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
@@ -252,21 +252,24 @@
                    value="result_text"
                    (change)="resultText = !resultText"
                    [checked]="precheckedCsvOptions.includes('result_text') && resultText">
-            <span i18n="csv options">Before Match</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Preceding context</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Before Match</span>
           </label>
           <label i18n-title title="The transcription of the match">
             <input type="checkbox" name="csv_option"
                    value="result_text"
                    (change)="resultText = !resultText"
                    [checked]="precheckedCsvOptions.includes('result_text') && resultText">
-            <span i18n="csv options">Text</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Transcript text</span>
+            <span *ngIf="displayExportNames" i18n="csv options">Text</span>
           </label>
           <label i18n-title title="The transcription of the context after the match">
             <input type="checkbox" name="csv_option"
                    value="result_text"
                    (change)="resultText = !resultText"
                    [checked]="precheckedCsvOptions.includes('result_text') && resultText">
-            <span i18n="csv options">After Match</span>
+            <span *ngIf="!displayExportNames" i18n="csv options">Following context</span>
+            <span *ngIf="displayExportNames" i18n="csv options">After Match</span>
           </label>
         </fieldset>
           <fieldset class="csv-controls">

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
@@ -236,11 +236,26 @@
                    *ngIf="precheckedCsvOptions.includes('word_url')">
             <span i18n="csv options">URL</span>
           </label>
-          <label i18n-title title="The transcription of the match and its surrounding context">
+          <label i18n-title title="The transcription of the context before the match">
             <input type="checkbox" name="csv_option"
                    value="result_text"
-                   [checked]="precheckedCsvOptions.includes('result_text')">
+                   (change)="resultText = !resultText"
+                   [checked]="precheckedCsvOptions.includes('result_text') && resultText">
+            <span i18n="csv options">Before Match</span>
+          </label>
+          <label i18n-title title="The transcription of the match">
+            <input type="checkbox" name="csv_option"
+                   value="result_text"
+                   (change)="resultText = !resultText"
+                   [checked]="precheckedCsvOptions.includes('result_text') && resultText">
             <span i18n="csv options">Text</span>
+          </label>
+          <label i18n-title title="The transcription of the context after the match">
+            <input type="checkbox" name="csv_option"
+                   value="result_text"
+                   (change)="resultText = !resultText"
+                   [checked]="precheckedCsvOptions.includes('result_text') && resultText">
+            <span i18n="csv options">After Match</span>
           </label>
         </fieldset>
         <!-- TODO disable segment layer anchoring when segment is targeted -->

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.html
@@ -280,7 +280,7 @@
         <!-- TODO disable segment layer anchoring when segment is targeted -->
         <lib-layer-checkboxes
           name="csv_layer"
-          includeCounts="true" 
+          includeCounts="true" [displayCsvNames]="displayExportNames"
           participant="true" transcript="true"
           span="true" phrase="true" word="true" segment="true"
           excludeMainParticipant="true" excludeTurn="true" excludeUtterance="true"

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.ts
@@ -43,6 +43,7 @@ export class MatchesComponent implements OnInit {
     precheckedCsvOptions = [
         "labbcat_title", "data_version", "collection_name", "result_number",
         "line_time", "line_end_time", "match", "word_url", "result_text"];
+    resultText = this.precheckedCsvOptions.includes("result_text");
     selectedLayers: string[];
     showEmuOptions = false;
     emuLayers = [ "word", "segment" ];

--- a/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.ts
+++ b/user-interface/src/main/angular/projects/labbcat-view/src/app/matches/matches.component.ts
@@ -44,6 +44,7 @@ export class MatchesComponent implements OnInit {
         "labbcat_title", "data_version", "collection_name", "result_number",
         "line_time", "line_end_time", "match", "word_url", "result_text"];
     resultText = this.precheckedCsvOptions.includes("result_text");
+    displayExportNames: boolean;
     selectedLayers: string[];
     showEmuOptions = false;
     emuLayers = [ "word", "segment" ];
@@ -101,6 +102,7 @@ export class MatchesComponent implements OnInit {
         this.readSerializers();
         this.readGenerableLayers();
         this.readEmuWebappSetting();
+        this.displayExportNames = JSON.parse(sessionStorage.getItem("displayCSVExportNames")) ?? false;
     }
 
     readBaseUrl(): void {
@@ -325,6 +327,10 @@ export class MatchesComponent implements OnInit {
         this.todo.nativeElement.value = "csv";
         this.form.nativeElement.action = this.baseUrl + "api/results";
         this.form.nativeElement.submit();
+    }
+    toggleExportNames(): void {
+        this.displayExportNames = !this.displayExportNames;
+        sessionStorage.setItem("displayCSVExportNames", JSON.stringify(this.displayExportNames));
     }
 
     serializationOptions(): void {


### PR DESCRIPTION
- Split _Text_ into 3 synced checkboxes: _Preceding context_, _Transcript text_, and _Following context_
- Option to show field names as they appear in the exported file (including for _participant_ and _transcript_)

Plus a styling tweak to make _Fields_ look like the other columns.

Note: HTML not reindented.